### PR TITLE
[WO-922] Check if CONDSTORE is supported before using CHANGEDSINCE modifier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.11"
+  - 0.12
 before_script:
   - npm install -g grunt-cli
 notifications:


### PR DESCRIPTION
Yahoo returns HIGHESTMODSEQ value when running SELECT but it does not support the CONDSTORE extensions (instead it supports a proprietary XYMHIGHESTMODSEQ). As the highestModseq value is detected, the _checkModseq method tries to run a FETCH with CHANGEDSINCE and MODSEQ arguments – both values are unknown for Yahoo, so you always get an error for the FETCH call. This update changes the behavior to look if CONDSTORE is listed in capabilities or not before doing the FETCH.