### PR TITLE
Handle login errors by rejecting as a promise should.

### DIFF
--- a/test/unit-test.js
+++ b/test/unit-test.js
@@ -40,6 +40,17 @@
                 bboxMock.onauth();
             });
 
+            it('should reject on login failure', function(done) {
+                imap._loggedIn = false;
+                imap.login()
+                .catch(function() {
+                    expect(imap._loggedIn).to.be.false;
+                    expect(bboxMock.connect.calledOnce).to.be.true;
+                    done();
+                });
+                bboxMock.onerror('login error');
+            });
+
             it('should not login when logged in', function(done) {
                 imap._loggedIn = true;
                 imap.login().then(done);


### PR DESCRIPTION
The implementation for ImapClient.login() returns a promise, but to catch errors consumers have to listen to the onerror events.  Generally promises should reject on errors.  This PR modifies ImapClient to listen to onerror and reject the promise if authentication fails. This will provide a promise centric interface for consumers.